### PR TITLE
no-store削除

### DIFF
--- a/frontend/src/app/members/[id]/page.tsx
+++ b/frontend/src/app/members/[id]/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { MemberRadarChart } from "@/components/MemberRadarChart";
 
+export const revalidate = 3600; // 🔥 1時間キャッシュ
 
 // メンバーの詳細情報の型定義
 export type MemberStatus = {
@@ -79,7 +80,6 @@ const defaultTheme = {
 async function getMember(id: string): Promise<Member> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/${id}`,
-    { cache: "no-store" }
   );
 
   if (!res.ok) {

--- a/frontend/src/app/members/page.tsx
+++ b/frontend/src/app/members/page.tsx
@@ -1,6 +1,7 @@
 // src/app/members/page.tsx
 import MembersDropdown from "./MembersDropdown";
 
+export const revalidate = 3600; // 🔥 1時間キャッシュ
 
 type Member = {
   id: number;
@@ -15,9 +16,6 @@ type Member = {
 async function getMembers(): Promise<Member[]> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/members`,
-    {
-      cache: "no-store", // 常に最新を取得（本番確認用）
-    }
   );
 
   if (!res.ok) {


### PR DESCRIPTION
## 変更内容

- fetch の `cache: "no-store"` を削除
- `export const revalidate = 3600;` を追加

## 目的

毎回SSRが実行され初回表示が遅くなっていたため、
ISR（Incremental Static Regeneration）を利用して
ページを1時間キャッシュするように変更しました。

